### PR TITLE
Implement domain objects with tests

### DIFF
--- a/Flashnotes/CMakeLists.txt
+++ b/Flashnotes/CMakeLists.txt
@@ -4,19 +4,34 @@ project(Flashnotes LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Fetch GoogleTest
+# Fetch dependencies
 include(FetchContent)
 FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
 )
-# For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+FetchContent_Declare(
+    nlohmann_json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
+add_library(domain
+    src/domain/note.cpp
+    src/domain/flashcard.cpp
+    src/domain/folder.cpp
+)
+target_include_directories(domain PUBLIC include)
+target_link_libraries(domain nlohmann_json::nlohmann_json)
+
 add_executable(flashnotes src/main.cpp)
+target_link_libraries(flashnotes domain)
 
 enable_testing()
-add_executable(test_flashnotes tests/smoke.cpp)
-target_link_libraries(test_flashnotes gtest_main)
-add_test(NAME smoke COMMAND test_flashnotes)
+file(GLOB TEST_SOURCES tests/*.cpp)
+add_executable(test_flashnotes ${TEST_SOURCES})
+target_link_libraries(test_flashnotes gtest_main domain nlohmann_json::nlohmann_json)
+add_test(NAME all_tests COMMAND test_flashnotes)

--- a/Flashnotes/include/domain/flashcard.hpp
+++ b/Flashnotes/include/domain/flashcard.hpp
@@ -1,0 +1,21 @@
+#ifndef FLASHNOTES_DOMAIN_FLASHCARD_HPP
+#define FLASHNOTES_DOMAIN_FLASHCARD_HPP
+
+#include <string>
+#include <nlohmann/json.hpp>
+
+namespace flashnotes {
+
+struct Flashcard {
+    int id{};
+    std::string front;
+    std::string back;
+    double successRate{0.5};
+};
+
+void to_json(nlohmann::json& j, const Flashcard& c);
+void from_json(const nlohmann::json& j, Flashcard& c);
+
+} // namespace flashnotes
+
+#endif // FLASHNOTES_DOMAIN_FLASHCARD_HPP

--- a/Flashnotes/include/domain/folder.hpp
+++ b/Flashnotes/include/domain/folder.hpp
@@ -1,0 +1,21 @@
+#ifndef FLASHNOTES_DOMAIN_FOLDER_HPP
+#define FLASHNOTES_DOMAIN_FOLDER_HPP
+
+#include <string>
+#include <vector>
+#include <nlohmann/json.hpp>
+
+namespace flashnotes {
+
+struct Folder {
+    int id{};
+    std::string name;
+    std::vector<int> childrenIds;
+};
+
+void to_json(nlohmann::json& j, const Folder& f);
+void from_json(const nlohmann::json& j, Folder& f);
+
+} // namespace flashnotes
+
+#endif // FLASHNOTES_DOMAIN_FOLDER_HPP

--- a/Flashnotes/include/domain/note.hpp
+++ b/Flashnotes/include/domain/note.hpp
@@ -1,0 +1,21 @@
+#ifndef FLASHNOTES_DOMAIN_NOTE_HPP
+#define FLASHNOTES_DOMAIN_NOTE_HPP
+
+#include <string>
+#include <nlohmann/json.hpp>
+
+namespace flashnotes {
+
+struct Note {
+    int id{};
+    std::string title;
+    std::string body;
+    std::string savedPath;
+};
+
+void to_json(nlohmann::json& j, const Note& n);
+void from_json(const nlohmann::json& j, Note& n);
+
+} // namespace flashnotes
+
+#endif // FLASHNOTES_DOMAIN_NOTE_HPP

--- a/Flashnotes/src/domain/flashcard.cpp
+++ b/Flashnotes/src/domain/flashcard.cpp
@@ -1,0 +1,18 @@
+#include "domain/flashcard.hpp"
+
+namespace flashnotes {
+
+void to_json(nlohmann::json& j, const Flashcard& c) {
+    j = nlohmann::json{{"id", c.id}, {"front", c.front}, {"back", c.back}, {"successRate", c.successRate}};
+}
+
+void from_json(const nlohmann::json& j, Flashcard& c) {
+    j.at("id").get_to(c.id);
+    j.at("front").get_to(c.front);
+    j.at("back").get_to(c.back);
+    if (j.contains("successRate")) {
+        j.at("successRate").get_to(c.successRate);
+    }
+}
+
+} // namespace flashnotes

--- a/Flashnotes/src/domain/folder.cpp
+++ b/Flashnotes/src/domain/folder.cpp
@@ -1,0 +1,15 @@
+#include "domain/folder.hpp"
+
+namespace flashnotes {
+
+void to_json(nlohmann::json& j, const Folder& f) {
+    j = nlohmann::json{{"id", f.id}, {"name", f.name}, {"childrenIds", f.childrenIds}};
+}
+
+void from_json(const nlohmann::json& j, Folder& f) {
+    j.at("id").get_to(f.id);
+    j.at("name").get_to(f.name);
+    j.at("childrenIds").get_to(f.childrenIds);
+}
+
+} // namespace flashnotes

--- a/Flashnotes/src/domain/note.cpp
+++ b/Flashnotes/src/domain/note.cpp
@@ -1,0 +1,16 @@
+#include "domain/note.hpp"
+
+namespace flashnotes {
+
+void to_json(nlohmann::json& j, const Note& n) {
+    j = nlohmann::json{{"id", n.id}, {"title", n.title}, {"body", n.body}, {"savedPath", n.savedPath}};
+}
+
+void from_json(const nlohmann::json& j, Note& n) {
+    j.at("id").get_to(n.id);
+    j.at("title").get_to(n.title);
+    j.at("body").get_to(n.body);
+    j.at("savedPath").get_to(n.savedPath);
+}
+
+} // namespace flashnotes

--- a/Flashnotes/tests/domain_flashcard.cpp
+++ b/Flashnotes/tests/domain_flashcard.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+#include "domain/flashcard.hpp"
+#include <nlohmann/json.hpp>
+
+using flashnotes::Flashcard;
+using nlohmann::json;
+
+TEST(FlashcardTest, DefaultRateAndJson) {
+    Flashcard c{2, "front", "back"};
+    EXPECT_DOUBLE_EQ(c.successRate, 0.5);
+    json j = c;
+    Flashcard out = j.get<Flashcard>();
+    EXPECT_EQ(out.front, c.front);
+    EXPECT_DOUBLE_EQ(out.successRate, 0.5);
+}

--- a/Flashnotes/tests/domain_folder.cpp
+++ b/Flashnotes/tests/domain_folder.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+#include "domain/folder.hpp"
+#include <nlohmann/json.hpp>
+
+using flashnotes::Folder;
+using nlohmann::json;
+
+TEST(FolderTest, VectorSerialization) {
+    Folder f{3, "root", {1,2}};
+    json j = f;
+    ASSERT_TRUE(j["childrenIds"].is_array());
+    Folder out = j.get<Folder>();
+    EXPECT_EQ(out.childrenIds.size(), 2u);
+    EXPECT_EQ(out.childrenIds[0], 1);
+}

--- a/Flashnotes/tests/domain_note.cpp
+++ b/Flashnotes/tests/domain_note.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "domain/note.hpp"
+#include <nlohmann/json.hpp>
+
+using flashnotes::Note;
+using nlohmann::json;
+
+TEST(NoteTest, SerializeDeserialize) {
+    Note n{1, "title", "body", "/tmp"};
+    json j = n;
+    EXPECT_EQ(j["id"], 1);
+    EXPECT_EQ(j["title"], "title");
+    Note out = j.get<Note>();
+    EXPECT_EQ(out.id, n.id);
+    EXPECT_EQ(out.savedPath, n.savedPath);
+}


### PR DESCRIPTION
## Summary
- add domain structs `Note`, `Flashcard` and `Folder`
- provide JSON serialization helpers using nlohmann/json
- include new domain library in CMake
- add unit tests for each domain object

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6841622c5594832c9f504d6449baf18a