### PR TITLE
Add logging and JSON persistence

### DIFF
--- a/Flashnotes/CMakeLists.txt
+++ b/Flashnotes/CMakeLists.txt
@@ -27,11 +27,23 @@ add_library(domain
 target_include_directories(domain PUBLIC include)
 target_link_libraries(domain nlohmann_json::nlohmann_json)
 
+add_library(utils
+    src/utils/Logger.cpp
+)
+target_include_directories(utils PUBLIC include)
+
+add_library(services
+    src/services/JsonPersistenceService.cpp
+)
+target_include_directories(services PUBLIC include)
+target_link_libraries(services domain utils nlohmann_json::nlohmann_json)
+target_compile_definitions(services PUBLIC UNIT_TEST)
+
 add_executable(flashnotes src/main.cpp)
-target_link_libraries(flashnotes domain)
+target_link_libraries(flashnotes domain utils services)
 
 enable_testing()
 file(GLOB TEST_SOURCES tests/*.cpp)
 add_executable(test_flashnotes ${TEST_SOURCES})
-target_link_libraries(test_flashnotes gtest_main domain nlohmann_json::nlohmann_json)
+target_link_libraries(test_flashnotes gtest_main domain utils services nlohmann_json::nlohmann_json)
 add_test(NAME all_tests COMMAND test_flashnotes)

--- a/Flashnotes/include/domain/material.hpp
+++ b/Flashnotes/include/domain/material.hpp
@@ -1,0 +1,17 @@
+#ifndef FLASHNOTES_DOMAIN_MATERIAL_HPP
+#define FLASHNOTES_DOMAIN_MATERIAL_HPP
+
+#include <nlohmann/json.hpp>
+
+namespace flashnotes {
+
+struct Material {
+    int id{};
+};
+
+inline void to_json(nlohmann::json& j, const Material& m) { j = nlohmann::json{{"id", m.id}}; }
+inline void from_json(const nlohmann::json& j, Material& m) { j.at("id").get_to(m.id); }
+
+} // namespace flashnotes
+
+#endif // FLASHNOTES_DOMAIN_MATERIAL_HPP

--- a/Flashnotes/include/services/JsonPersistenceService.hpp
+++ b/Flashnotes/include/services/JsonPersistenceService.hpp
@@ -1,0 +1,82 @@
+#pragma once
+#include <filesystem>
+#include <vector>
+#include <fstream>
+#include <cstdlib>
+#include <nlohmann/json.hpp>
+
+#include "domain/note.hpp"
+#include "domain/folder.hpp"
+#include "domain/flashcard.hpp"
+#include "utils/Logger.hpp"
+
+namespace flashnotes {
+
+struct Material; // forward declaration
+
+class JsonPersistenceService final {
+public:
+    template <typename T>
+    static std::vector<T> load(const std::filesystem::path& file);
+
+    template <typename T>
+    static void save(const std::filesystem::path& file, const std::vector<T>& data);
+
+    static std::vector<Note>      loadNotes();
+    static std::vector<Folder>    loadFolders();
+    static std::vector<Flashcard> loadFlashcards();
+    static std::vector<Material>  loadMaterials();
+
+    static void saveNotes     (const std::vector<Note>&);
+    static void saveFolders   (const std::vector<Folder>&);
+    static void saveFlashcards(const std::vector<Flashcard>&);
+    static void saveMaterials (const std::vector<Material>&);
+
+#ifdef UNIT_TEST
+    static void setDataRoot(const std::filesystem::path&);
+#endif
+
+private:
+    static const std::filesystem::path& dataRoot();
+};
+
+// Template implementations
+
+template <typename T>
+std::vector<T> JsonPersistenceService::load(const std::filesystem::path& file) {
+    namespace fs = std::filesystem;
+    fs::path path = dataRoot() / file;
+    std::vector<T> result;
+    if (!fs::exists(path)) {
+        return result;
+    }
+    try {
+        std::ifstream in(path);
+        if (!in) {
+            return result;
+        }
+        nlohmann::json j; in >> j;
+        result = j.get<std::vector<T>>();
+    } catch (const std::exception& e) {
+        Logger::error(e.what());
+        throw;
+    }
+    return result;
+}
+
+template <typename T>
+void JsonPersistenceService::save(const std::filesystem::path& file, const std::vector<T>& data) {
+    namespace fs = std::filesystem;
+    fs::path path = dataRoot() / file;
+    try {
+        fs::create_directories(path.parent_path());
+        std::ofstream out(path);
+        nlohmann::json j = data;
+        out << j.dump(4);
+    } catch (const std::exception& e) {
+        Logger::error(e.what());
+        throw;
+    }
+}
+
+} // namespace flashnotes

--- a/Flashnotes/include/utils/Logger.hpp
+++ b/Flashnotes/include/utils/Logger.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <string>
+#include <iostream>
+
+namespace flashnotes {
+
+class Logger {
+public:
+    enum class Level { DEBUG, INFO, WARN, ERROR };
+    static void setLevel(Level);
+    static void debug(const std::string&);
+    static void info (const std::string&);
+    static void warn (const std::string&);
+    static void error(const std::string&);
+private:
+    static Level current;
+    static void log(Level, const std::string&);
+};
+
+} // namespace flashnotes

--- a/Flashnotes/src/services/JsonPersistenceService.cpp
+++ b/Flashnotes/src/services/JsonPersistenceService.cpp
@@ -1,0 +1,59 @@
+#include "services/JsonPersistenceService.hpp"
+#include "domain/material.hpp"
+
+namespace flashnotes {
+
+namespace fs = std::filesystem;
+
+static fs::path g_root;
+
+const fs::path& JsonPersistenceService::dataRoot() {
+    if (g_root.empty()) {
+        if (const char* env = std::getenv("APPDATA")) {
+            g_root = fs::path(env) / "Flashnotes";
+        } else {
+            g_root = fs::path("data");
+        }
+    }
+    return g_root;
+}
+
+#ifdef UNIT_TEST
+void JsonPersistenceService::setDataRoot(const fs::path& p) {
+    g_root = p;
+}
+#endif
+
+std::vector<Note> JsonPersistenceService::loadNotes() {
+    return load<Note>("notes.json");
+}
+
+std::vector<Folder> JsonPersistenceService::loadFolders() {
+    return load<Folder>("folders.json");
+}
+
+std::vector<Flashcard> JsonPersistenceService::loadFlashcards() {
+    return load<Flashcard>("flashcards.json");
+}
+
+std::vector<Material> JsonPersistenceService::loadMaterials() {
+    return {};
+}
+
+void JsonPersistenceService::saveNotes(const std::vector<Note>& notes) {
+    save("notes.json", notes);
+}
+
+void JsonPersistenceService::saveFolders(const std::vector<Folder>& folders) {
+    save("folders.json", folders);
+}
+
+void JsonPersistenceService::saveFlashcards(const std::vector<Flashcard>& cards) {
+    save("flashcards.json", cards);
+}
+
+void JsonPersistenceService::saveMaterials(const std::vector<Material>&) {
+    // stub
+}
+
+} // namespace flashnotes

--- a/Flashnotes/src/utils/Logger.cpp
+++ b/Flashnotes/src/utils/Logger.cpp
@@ -1,0 +1,32 @@
+#include "utils/Logger.hpp"
+#include <iostream>
+
+namespace flashnotes {
+
+Logger::Level Logger::current = Logger::Level::INFO;
+
+namespace {
+const char* toString(Logger::Level lvl) {
+    switch (lvl) {
+    case Logger::Level::DEBUG: return "DEBUG";
+    case Logger::Level::INFO:  return "INFO";
+    case Logger::Level::WARN:  return "WARN";
+    case Logger::Level::ERROR: return "ERROR";
+    }
+    return "";
+}
+} // unnamed
+
+void Logger::setLevel(Level lvl) { current = lvl; }
+
+void Logger::log(Level lvl, const std::string& msg) {
+    if (lvl < current) return;
+    std::clog << '[' << toString(lvl) << "] " << msg << std::endl;
+}
+
+void Logger::debug(const std::string& m) { log(Level::DEBUG, m); }
+void Logger::info(const std::string& m)  { log(Level::INFO, m); }
+void Logger::warn(const std::string& m)  { log(Level::WARN, m); }
+void Logger::error(const std::string& m) { log(Level::ERROR, m); }
+
+} // namespace flashnotes

--- a/Flashnotes/tests/persistence_folder.cpp
+++ b/Flashnotes/tests/persistence_folder.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#define UNIT_TEST
+#include "services/JsonPersistenceService.hpp"
+#include <filesystem>
+
+using namespace flashnotes;
+namespace fs = std::filesystem;
+
+TEST(Persistence, FolderRoundTrip) {
+    fs::path temp = fs::temp_directory_path() / "flashnotes_folder";
+    JsonPersistenceService::setDataRoot(temp);
+    std::vector<Folder> folders{{1,"f1",{2,3}},{2,"f2",{}}};
+    JsonPersistenceService::saveFolders(folders);
+    auto loaded = JsonPersistenceService::loadFolders();
+    ASSERT_EQ(loaded.size(), folders.size());
+    EXPECT_EQ(loaded[0].childrenIds[0], folders[0].childrenIds[0]);
+    EXPECT_EQ(loaded[1].name, folders[1].name);
+}

--- a/Flashnotes/tests/persistence_note.cpp
+++ b/Flashnotes/tests/persistence_note.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#define UNIT_TEST
+#include "services/JsonPersistenceService.hpp"
+#include <filesystem>
+
+using namespace flashnotes;
+namespace fs = std::filesystem;
+
+TEST(Persistence, NoteRoundTrip) {
+    fs::path temp = fs::temp_directory_path() / "flashnotes_note";
+    JsonPersistenceService::setDataRoot(temp);
+    std::vector<Note> notes{{1,"t1","b1","/p1"},{2,"t2","b2","/p2"}};
+    JsonPersistenceService::saveNotes(notes);
+    auto loaded = JsonPersistenceService::loadNotes();
+    ASSERT_EQ(loaded.size(), notes.size());
+    EXPECT_EQ(loaded[0].title, notes[0].title);
+    EXPECT_EQ(loaded[1].body, notes[1].body);
+}


### PR DESCRIPTION
## Summary
- add simple Logger utility
- implement JsonPersistenceService with load/save helpers
- provide stub Material domain
- round-trip persistence unit tests for notes and folders

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68419fbde098832cad3227d64c195fa2