### PR TITLE
Add service layer with persistence tests

### DIFF
--- a/Flashnotes/CMakeLists.txt
+++ b/Flashnotes/CMakeLists.txt
@@ -34,6 +34,9 @@ target_include_directories(utils PUBLIC include)
 
 add_library(services
     src/services/JsonPersistenceService.cpp
+    src/services/NotesService.cpp
+    src/services/FileService.cpp
+    src/services/FlashcardService.cpp
 )
 target_include_directories(services PUBLIC include)
 target_link_libraries(services domain utils nlohmann_json::nlohmann_json)

--- a/Flashnotes/include/services/FileService.hpp
+++ b/Flashnotes/include/services/FileService.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <vector>
+#include <filesystem>
+#include "domain/material.hpp"
+#include "services/JsonPersistenceService.hpp"
+
+namespace flashnotes {
+
+class FileService {
+public:
+    FileService();
+    Material create();
+    std::vector<Material> list() const;
+    void remove(std::uint64_t id);
+
+private:
+    std::vector<Material> cache_;
+    int nextId() const;
+    void syncFromDisk();
+    void syncToDisk() const;
+};
+
+} // namespace flashnotes

--- a/Flashnotes/include/services/FlashcardService.hpp
+++ b/Flashnotes/include/services/FlashcardService.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <vector>
+#include <filesystem>
+#include "domain/flashcard.hpp"
+#include "services/JsonPersistenceService.hpp"
+
+namespace flashnotes {
+
+class FlashcardService {
+public:
+    FlashcardService();
+    Flashcard create(const std::string& front,
+                     const std::string& back);
+    std::vector<Flashcard> list() const;
+    void remove(std::uint64_t id);
+    std::vector<Flashcard> getNextCards(std::size_t n) const;
+
+private:
+    std::vector<Flashcard> cache_;
+    int nextId() const;
+    void syncFromDisk();
+    void syncToDisk() const;
+};
+
+} // namespace flashnotes

--- a/Flashnotes/include/services/NotesService.hpp
+++ b/Flashnotes/include/services/NotesService.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <vector>
+#include <filesystem>
+#include "domain/note.hpp"
+#include "services/JsonPersistenceService.hpp"
+
+namespace flashnotes {
+
+class NotesService {
+public:
+    NotesService();
+
+    Note create(const std::string& title,
+                const std::string& body,
+                const std::filesystem::path& savePath);
+
+    std::vector<Note> list() const;
+    void remove(std::uint64_t id);
+
+private:
+    std::vector<Note> cache_;
+    int nextId() const;
+    void syncFromDisk();
+    void syncToDisk() const;
+};
+
+} // namespace flashnotes

--- a/Flashnotes/src/services/FileService.cpp
+++ b/Flashnotes/src/services/FileService.cpp
@@ -1,0 +1,40 @@
+#include "services/FileService.hpp"
+#include <algorithm>
+
+namespace flashnotes {
+
+FileService::FileService() { syncFromDisk(); }
+
+int FileService::nextId() const {
+    int id = 0;
+    for (const auto& m : cache_) if (m.id > id) id = m.id;
+    return id + 1;
+}
+
+Material FileService::create() {
+    Material m{nextId()};
+    cache_.push_back(m);
+    syncToDisk();
+    return m;
+}
+
+std::vector<Material> FileService::list() const {
+    return cache_;
+}
+
+void FileService::remove(std::uint64_t id) {
+    cache_.erase(std::remove_if(cache_.begin(), cache_.end(),
+                 [id](const Material& m){ return static_cast<std::uint64_t>(m.id)==id; }),
+                 cache_.end());
+    syncToDisk();
+}
+
+void FileService::syncFromDisk() {
+    cache_ = JsonPersistenceService::loadMaterials();
+}
+
+void FileService::syncToDisk() const {
+    JsonPersistenceService::saveMaterials(cache_);
+}
+
+} // namespace flashnotes

--- a/Flashnotes/src/services/FlashcardService.cpp
+++ b/Flashnotes/src/services/FlashcardService.cpp
@@ -1,0 +1,49 @@
+#include "services/FlashcardService.hpp"
+#include <algorithm>
+
+namespace flashnotes {
+
+FlashcardService::FlashcardService() { syncFromDisk(); }
+
+int FlashcardService::nextId() const {
+    int id = 0;
+    for (const auto& c : cache_) if (c.id > id) id = c.id;
+    return id + 1;
+}
+
+Flashcard FlashcardService::create(const std::string& front,
+                                   const std::string& back) {
+    Flashcard c{nextId(), front, back};
+    cache_.push_back(c);
+    syncToDisk();
+    return c;
+}
+
+std::vector<Flashcard> FlashcardService::list() const {
+    return cache_;
+}
+
+void FlashcardService::remove(std::uint64_t id) {
+    cache_.erase(std::remove_if(cache_.begin(), cache_.end(),
+                 [id](const Flashcard& c){ return static_cast<std::uint64_t>(c.id)==id; }),
+                 cache_.end());
+    syncToDisk();
+}
+
+std::vector<Flashcard> FlashcardService::getNextCards(std::size_t n) const {
+    std::vector<Flashcard> result;
+    for (std::size_t i = 0; i < n && i < cache_.size(); ++i) {
+        result.push_back(cache_[i]);
+    }
+    return result;
+}
+
+void FlashcardService::syncFromDisk() {
+    cache_ = JsonPersistenceService::loadFlashcards();
+}
+
+void FlashcardService::syncToDisk() const {
+    JsonPersistenceService::saveFlashcards(cache_);
+}
+
+} // namespace flashnotes

--- a/Flashnotes/src/services/JsonPersistenceService.cpp
+++ b/Flashnotes/src/services/JsonPersistenceService.cpp
@@ -37,7 +37,7 @@ std::vector<Flashcard> JsonPersistenceService::loadFlashcards() {
 }
 
 std::vector<Material> JsonPersistenceService::loadMaterials() {
-    return {};
+    return load<Material>("materials.json");
 }
 
 void JsonPersistenceService::saveNotes(const std::vector<Note>& notes) {
@@ -52,8 +52,8 @@ void JsonPersistenceService::saveFlashcards(const std::vector<Flashcard>& cards)
     save("flashcards.json", cards);
 }
 
-void JsonPersistenceService::saveMaterials(const std::vector<Material>&) {
-    // stub
+void JsonPersistenceService::saveMaterials(const std::vector<Material>& mats) {
+    save("materials.json", mats);
 }
 
 } // namespace flashnotes

--- a/Flashnotes/src/services/NotesService.cpp
+++ b/Flashnotes/src/services/NotesService.cpp
@@ -1,0 +1,41 @@
+#include "services/NotesService.hpp"
+
+namespace flashnotes {
+
+NotesService::NotesService() { syncFromDisk(); }
+
+int NotesService::nextId() const {
+    int id = 0;
+    for (const auto& n : cache_) if (n.id > id) id = n.id;
+    return id + 1;
+}
+
+Note NotesService::create(const std::string& title,
+                          const std::string& body,
+                          const std::filesystem::path& savePath) {
+    Note n{nextId(), title, body, savePath.string()};
+    cache_.push_back(n);
+    syncToDisk();
+    return n;
+}
+
+std::vector<Note> NotesService::list() const {
+    return cache_;
+}
+
+void NotesService::remove(std::uint64_t id) {
+    cache_.erase(std::remove_if(cache_.begin(), cache_.end(),
+                 [id](const Note& n){ return static_cast<std::uint64_t>(n.id)==id; }),
+                 cache_.end());
+    syncToDisk();
+}
+
+void NotesService::syncFromDisk() {
+    cache_ = JsonPersistenceService::loadNotes();
+}
+
+void NotesService::syncToDisk() const {
+    JsonPersistenceService::saveNotes(cache_);
+}
+
+} // namespace flashnotes

--- a/Flashnotes/tests/file_service.cpp
+++ b/Flashnotes/tests/file_service.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+#define UNIT_TEST
+#include "services/FileService.hpp"
+#include "services/JsonPersistenceService.hpp"
+#include <filesystem>
+
+using namespace flashnotes;
+namespace fs = std::filesystem;
+
+TEST(FileService, CreateList) {
+    fs::path root = fs::temp_directory_path() / "file_service_create";
+    fs::remove_all(root);
+    JsonPersistenceService::setDataRoot(root);
+    FileService svc;
+    auto m = svc.create();
+    auto list = svc.list();
+    ASSERT_EQ(list.size(), 1u);
+    EXPECT_EQ(list[0].id, m.id);
+}
+
+TEST(FileService, RemovePersists) {
+    fs::path root = fs::temp_directory_path() / "file_service_remove";
+    fs::remove_all(root);
+    JsonPersistenceService::setDataRoot(root);
+    FileService svc;
+    auto m = svc.create();
+    svc.remove(m.id);
+    JsonPersistenceService::setDataRoot(root);
+    FileService reload;
+    EXPECT_TRUE(reload.list().empty());
+}

--- a/Flashnotes/tests/flashcard_service.cpp
+++ b/Flashnotes/tests/flashcard_service.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+#define UNIT_TEST
+#include "services/FlashcardService.hpp"
+#include "services/JsonPersistenceService.hpp"
+#include <filesystem>
+
+using namespace flashnotes;
+namespace fs = std::filesystem;
+
+TEST(FlashcardService, CreateList) {
+    fs::path root = fs::temp_directory_path() / "flashcard_create";
+    fs::remove_all(root);
+    JsonPersistenceService::setDataRoot(root);
+    FlashcardService svc;
+    auto c = svc.create("f","b");
+    auto list = svc.list();
+    ASSERT_EQ(list.size(), 1u);
+    EXPECT_EQ(list[0].id, c.id);
+}
+
+TEST(FlashcardService, RemovePersists) {
+    fs::path root = fs::temp_directory_path() / "flashcard_remove";
+    fs::remove_all(root);
+    JsonPersistenceService::setDataRoot(root);
+    FlashcardService svc;
+    auto c = svc.create("f","b");
+    svc.remove(c.id);
+    JsonPersistenceService::setDataRoot(root);
+    FlashcardService reload;
+    EXPECT_TRUE(reload.list().empty());
+}
+
+TEST(FlashcardService, GetNextCardsLimit) {
+    fs::path root = fs::temp_directory_path() / "flashcard_next";
+    fs::remove_all(root);
+    JsonPersistenceService::setDataRoot(root);
+    FlashcardService svc;
+    svc.create("1","1");
+    svc.create("2","2");
+    svc.create("3","3");
+    auto next = svc.getNextCards(2);
+    ASSERT_LE(next.size(), 2u);
+    EXPECT_EQ(next[0].front, "1");
+}

--- a/Flashnotes/tests/notes_service.cpp
+++ b/Flashnotes/tests/notes_service.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+#define UNIT_TEST
+#include "services/NotesService.hpp"
+#include "services/JsonPersistenceService.hpp"
+#include <filesystem>
+
+using namespace flashnotes;
+namespace fs = std::filesystem;
+
+TEST(NotesService, CreateAndList) {
+    fs::path root = fs::temp_directory_path() / "notes_service_create";
+    fs::remove_all(root);
+    JsonPersistenceService::setDataRoot(root);
+    NotesService svc;
+    auto n = svc.create("t","b","/tmp");
+    auto all = svc.list();
+    ASSERT_EQ(all.size(), 1u);
+    EXPECT_EQ(all[0].id, n.id);
+}
+
+TEST(NotesService, RemovePersists) {
+    fs::path root = fs::temp_directory_path() / "notes_service_remove";
+    fs::remove_all(root);
+    JsonPersistenceService::setDataRoot(root);
+    NotesService svc;
+    auto n = svc.create("t","b","/tmp");
+    svc.remove(n.id);
+    JsonPersistenceService::setDataRoot(root);
+    NotesService reload;
+    EXPECT_TRUE(reload.list().empty());
+}


### PR DESCRIPTION
## Summary
- implement NotesService, FileService, FlashcardService
- persist data through JsonPersistenceService
- add unit tests for each service
- extend persistence for Material

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6841a1eb46c8832c85dcff3dd9f3724b