### PR TITLE
Implement controller layer with CLI demo

### DIFF
--- a/Flashnotes/CMakeLists.txt
+++ b/Flashnotes/CMakeLists.txt
@@ -42,11 +42,20 @@ target_include_directories(services PUBLIC include)
 target_link_libraries(services domain utils nlohmann_json::nlohmann_json)
 target_compile_definitions(services PUBLIC UNIT_TEST)
 
+add_library(controllers
+    src/controllers/AppController.cpp
+    src/controllers/NotesController.cpp
+    src/controllers/FileController.cpp
+    src/controllers/FlashcardController.cpp
+)
+target_include_directories(controllers PUBLIC include)
+target_link_libraries(controllers services)
+
 add_executable(flashnotes src/main.cpp)
-target_link_libraries(flashnotes domain utils services)
+target_link_libraries(flashnotes controllers domain utils services)
 
 enable_testing()
 file(GLOB TEST_SOURCES tests/*.cpp)
 add_executable(test_flashnotes ${TEST_SOURCES})
-target_link_libraries(test_flashnotes gtest_main domain utils services nlohmann_json::nlohmann_json)
+target_link_libraries(test_flashnotes gtest_main controllers domain utils services nlohmann_json::nlohmann_json)
 add_test(NAME all_tests COMMAND test_flashnotes)

--- a/Flashnotes/include/controllers/AppController.hpp
+++ b/Flashnotes/include/controllers/AppController.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "controllers/NotesController.hpp"
+#include "controllers/FileController.hpp"
+#include "controllers/FlashcardController.hpp"
+
+namespace flashnotes {
+
+class AppController {
+public:
+    AppController();
+
+    NotesController& notes();
+    FileController& files();
+    FlashcardController& flashcards();
+
+private:
+    NotesController notes_;
+    FileController files_;
+    FlashcardController flashcards_;
+};
+
+} // namespace flashnotes

--- a/Flashnotes/include/controllers/FileController.hpp
+++ b/Flashnotes/include/controllers/FileController.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include "domain/material.hpp"
+#include "services/FileService.hpp"
+#include "utils/Expected.hpp"
+
+namespace flashnotes {
+
+class FileController {
+public:
+    FileController();
+    explicit FileController(std::shared_ptr<FileService> svc);
+
+    Expected<Material> createFile();
+    Expected<std::vector<Material>> listFiles() const;
+    Expected<void> removeFile(std::uint64_t id);
+
+private:
+    std::shared_ptr<FileService> service_;
+};
+
+} // namespace flashnotes

--- a/Flashnotes/include/controllers/FlashcardController.hpp
+++ b/Flashnotes/include/controllers/FlashcardController.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <memory>
+#include <vector>
+#include "domain/flashcard.hpp"
+#include "services/FlashcardService.hpp"
+#include "utils/Expected.hpp"
+
+namespace flashnotes {
+
+class FlashcardController {
+public:
+    FlashcardController();
+    explicit FlashcardController(std::shared_ptr<FlashcardService> svc);
+
+    Expected<Flashcard> createFlashcard(const std::string& front,
+                                        const std::string& back);
+    Expected<std::vector<Flashcard>> listFlashcards() const;
+    Expected<void> removeFlashcard(std::uint64_t id);
+    Expected<std::vector<Flashcard>> getNextCards(std::size_t n) const;
+
+private:
+    std::shared_ptr<FlashcardService> service_;
+};
+
+} // namespace flashnotes

--- a/Flashnotes/include/controllers/NotesController.hpp
+++ b/Flashnotes/include/controllers/NotesController.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <memory>
+#include <filesystem>
+#include <vector>
+#include "domain/note.hpp"
+#include "services/NotesService.hpp"
+#include "utils/Expected.hpp"
+
+namespace flashnotes {
+
+class NotesController {
+public:
+    NotesController();
+    explicit NotesController(std::shared_ptr<NotesService> svc);
+
+    Expected<Note> createNote(const std::string& title,
+                              const std::string& body,
+                              const std::filesystem::path& savePath);
+    Expected<std::vector<Note>> listNotes() const;
+    Expected<void> removeNote(std::uint64_t id);
+
+private:
+    std::shared_ptr<NotesService> service_;
+};
+
+} // namespace flashnotes

--- a/Flashnotes/include/utils/Expected.hpp
+++ b/Flashnotes/include/utils/Expected.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <variant>
+#include <string>
+
+namespace flashnotes {
+
+template <typename T>
+class Expected {
+    std::variant<T, std::string> data_;
+public:
+    Expected(const T& val) : data_(val) {}
+    Expected(T&& val) : data_(std::move(val)) {}
+    Expected(const std::string& err) : data_(err) {}
+    Expected(std::string&& err) : data_(std::move(err)) {}
+    bool hasValue() const { return std::holds_alternative<T>(data_); }
+    explicit operator bool() const { return hasValue(); }
+    T& value() { return std::get<T>(data_); }
+    const T& value() const { return std::get<T>(data_); }
+    const std::string& error() const { return std::get<std::string>(data_); }
+};
+
+template <>
+class Expected<void> {
+    std::variant<std::monostate, std::string> data_;
+public:
+    Expected() : data_(std::monostate{}) {}
+    Expected(const std::string& err) : data_(err) {}
+    Expected(std::string&& err) : data_(std::move(err)) {}
+    bool hasValue() const { return std::holds_alternative<std::monostate>(data_); }
+    explicit operator bool() const { return hasValue(); }
+    void value() const {}
+    const std::string& error() const { return std::get<std::string>(data_); }
+};
+
+} // namespace flashnotes

--- a/Flashnotes/src/controllers/AppController.cpp
+++ b/Flashnotes/src/controllers/AppController.cpp
@@ -1,0 +1,11 @@
+#include "controllers/AppController.hpp"
+
+namespace flashnotes {
+
+AppController::AppController() = default;
+
+NotesController& AppController::notes() { return notes_; }
+FileController& AppController::files() { return files_; }
+FlashcardController& AppController::flashcards() { return flashcards_; }
+
+} // namespace flashnotes

--- a/Flashnotes/src/controllers/FileController.cpp
+++ b/Flashnotes/src/controllers/FileController.cpp
@@ -1,0 +1,36 @@
+#include "controllers/FileController.hpp"
+
+namespace flashnotes {
+
+FileController::FileController()
+    : service_(std::make_shared<FileService>()) {}
+
+FileController::FileController(std::shared_ptr<FileService> svc)
+    : service_(std::move(svc)) {}
+
+Expected<Material> FileController::createFile() {
+    try {
+        return service_->create();
+    } catch (const std::exception& e) {
+        return Expected<Material>(e.what());
+    }
+}
+
+Expected<std::vector<Material>> FileController::listFiles() const {
+    try {
+        return service_->list();
+    } catch (const std::exception& e) {
+        return Expected<std::vector<Material>>(e.what());
+    }
+}
+
+Expected<void> FileController::removeFile(std::uint64_t id) {
+    try {
+        service_->remove(id);
+        return Expected<void>();
+    } catch (const std::exception& e) {
+        return Expected<void>(e.what());
+    }
+}
+
+} // namespace flashnotes

--- a/Flashnotes/src/controllers/FlashcardController.cpp
+++ b/Flashnotes/src/controllers/FlashcardController.cpp
@@ -1,0 +1,48 @@
+#include "controllers/FlashcardController.hpp"
+
+namespace flashnotes {
+
+FlashcardController::FlashcardController()
+    : service_(std::make_shared<FlashcardService>()) {}
+
+FlashcardController::FlashcardController(std::shared_ptr<FlashcardService> svc)
+    : service_(std::move(svc)) {}
+
+Expected<Flashcard> FlashcardController::createFlashcard(const std::string& front,
+                                                         const std::string& back) {
+    if (front.empty()) {
+        return Expected<Flashcard>("Front must not be empty");
+    }
+    try {
+        return service_->create(front, back);
+    } catch (const std::exception& e) {
+        return Expected<Flashcard>(e.what());
+    }
+}
+
+Expected<std::vector<Flashcard>> FlashcardController::listFlashcards() const {
+    try {
+        return service_->list();
+    } catch (const std::exception& e) {
+        return Expected<std::vector<Flashcard>>(e.what());
+    }
+}
+
+Expected<void> FlashcardController::removeFlashcard(std::uint64_t id) {
+    try {
+        service_->remove(id);
+        return Expected<void>();
+    } catch (const std::exception& e) {
+        return Expected<void>(e.what());
+    }
+}
+
+Expected<std::vector<Flashcard>> FlashcardController::getNextCards(std::size_t n) const {
+    try {
+        return service_->getNextCards(n);
+    } catch (const std::exception& e) {
+        return Expected<std::vector<Flashcard>>(e.what());
+    }
+}
+
+} // namespace flashnotes

--- a/Flashnotes/src/controllers/NotesController.cpp
+++ b/Flashnotes/src/controllers/NotesController.cpp
@@ -1,0 +1,41 @@
+#include "controllers/NotesController.hpp"
+
+namespace flashnotes {
+
+NotesController::NotesController()
+    : service_(std::make_shared<NotesService>()) {}
+
+NotesController::NotesController(std::shared_ptr<NotesService> svc)
+    : service_(std::move(svc)) {}
+
+Expected<Note> NotesController::createNote(const std::string& title,
+                                           const std::string& body,
+                                           const std::filesystem::path& savePath) {
+    if (title.empty()) {
+        return Expected<Note>("Title must not be empty");
+    }
+    try {
+        return service_->create(title, body, savePath);
+    } catch (const std::exception& e) {
+        return Expected<Note>(e.what());
+    }
+}
+
+Expected<std::vector<Note>> NotesController::listNotes() const {
+    try {
+        return service_->list();
+    } catch (const std::exception& e) {
+        return Expected<std::vector<Note>>(e.what());
+    }
+}
+
+Expected<void> NotesController::removeNote(std::uint64_t id) {
+    try {
+        service_->remove(id);
+        return Expected<void>();
+    } catch (const std::exception& e) {
+        return Expected<void>(e.what());
+    }
+}
+
+} // namespace flashnotes

--- a/Flashnotes/src/main.cpp
+++ b/Flashnotes/src/main.cpp
@@ -1,6 +1,49 @@
 #include <iostream>
+#include "controllers/AppController.hpp"
+
+using namespace flashnotes;
 
 int main() {
-    std::cout << "Flashnotes skeleton" << std::endl;
+    try {
+        AppController app;
+
+        auto noteRes = app.notes().createNote("Sample", "Body", "/tmp");
+        if (!noteRes) {
+            std::cerr << noteRes.error() << std::endl;
+            return 1;
+        }
+        auto notes = app.notes().listNotes();
+        if (!notes) {
+            std::cerr << notes.error() << std::endl;
+            return 1;
+        }
+        std::cout << "Notes count: " << notes.value().size() << std::endl;
+
+        auto mat = app.files().createFile();
+        if (!mat) {
+            std::cerr << mat.error() << std::endl;
+            return 1;
+        }
+        auto mats = app.files().listFiles();
+        if (!mats) {
+            std::cerr << mats.error() << std::endl;
+            return 1;
+        }
+        std::cout << "Materials count: " << mats.value().size() << std::endl;
+
+        app.flashcards().createFlashcard("Q1", "A1");
+        app.flashcards().createFlashcard("Q2", "A2");
+        auto next = app.flashcards().getNextCards(1);
+        if (!next) {
+            std::cerr << next.error() << std::endl;
+            return 1;
+        }
+        for (const auto& c : next.value()) {
+            std::cout << "Card: " << c.front << " -> " << c.back << std::endl;
+        }
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
     return 0;
 }

--- a/Flashnotes/tests/notes_controller.cpp
+++ b/Flashnotes/tests/notes_controller.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#define UNIT_TEST
+#include "controllers/NotesController.hpp"
+#include "services/JsonPersistenceService.hpp"
+#include <filesystem>
+
+using namespace flashnotes;
+namespace fs = std::filesystem;
+
+TEST(NotesController, ThrowsOnEmptyTitle) {
+    fs::path root = fs::temp_directory_path() / "notes_controller_empty";
+    fs::remove_all(root);
+    JsonPersistenceService::setDataRoot(root);
+    NotesController ctrl;
+    auto res = ctrl.createNote("", "body", "/tmp");
+    EXPECT_FALSE(res);
+    EXPECT_EQ(res.error(), "Title must not be empty");
+}


### PR DESCRIPTION
## Summary
- add lightweight Expected utility
- implement Notes, File, Flashcard and App controllers
- wire controllers into CMake build
- update `main.cpp` with demo CLI using controllers
- add unit test for NotesController empty title validation

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `cd build && ctest --output-on-failure`
- `./build/flashnotes`

------
https://chatgpt.com/codex/tasks/task_e_6841a407a55c832c82b944465c815629