### PR TITLE
Add C++/CLI WinForms GUI

### DIFF
--- a/Flashnotes/CMakeLists.txt
+++ b/Flashnotes/CMakeLists.txt
@@ -40,7 +40,10 @@ add_library(services
 )
 target_include_directories(services PUBLIC include)
 target_link_libraries(services domain utils nlohmann_json::nlohmann_json)
-target_compile_definitions(services PUBLIC UNIT_TEST)
+# build the services library with UNIT_TEST enabled but do not
+# propagate the definition to consumers so production targets
+# remain clean of test hooks
+target_compile_definitions(services PRIVATE UNIT_TEST)
 
 add_library(controllers
     src/controllers/AppController.cpp
@@ -51,6 +54,10 @@ add_library(controllers
 target_include_directories(controllers PUBLIC include)
 target_link_libraries(controllers services)
 
+if(MSVC)
+    add_subdirectory(src/gui)
+endif()
+
 add_executable(flashnotes src/main.cpp)
 target_link_libraries(flashnotes controllers domain utils services)
 
@@ -58,4 +65,7 @@ enable_testing()
 file(GLOB TEST_SOURCES tests/*.cpp)
 add_executable(test_flashnotes ${TEST_SOURCES})
 target_link_libraries(test_flashnotes gtest_main controllers domain utils services nlohmann_json::nlohmann_json)
+# test sources rely on helper hooks enabled by the UNIT_TEST
+# definition in the services library
+target_compile_definitions(test_flashnotes PRIVATE UNIT_TEST)
 add_test(NAME all_tests COMMAND test_flashnotes)

--- a/Flashnotes/README.md
+++ b/Flashnotes/README.md
@@ -22,3 +22,9 @@ Run the tests:
 ```bash
 cd build && ctest
 ```
+
+### Optional WinForms GUI
+
+When using Visual Studio on Windows (MSVC), CMake also builds a `FlashnotesGUI`
+target providing a minimalist WinForms interface that links against the
+controllers.

--- a/Flashnotes/src/gui/CMakeLists.txt
+++ b/Flashnotes/src/gui/CMakeLists.txt
@@ -1,0 +1,39 @@
+if(NOT MSVC)
+    return()
+endif()
+
+# Remove default /RTC1 runtime checks and /EHsc which conflict with /clr
+foreach(flag_var
+    CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+    CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    string(REPLACE "/RTC1" "" ${flag_var} "${${flag_var}}")
+    string(REPLACE "/EHsc" "" ${flag_var} "${${flag_var}}")
+endforeach()
+
+set(SOURCES
+    Program.cpp
+    MainWindow.cpp
+    NoteEditorForm.cpp
+    FileManagerForm.cpp
+    FlashcardPracticeForm.cpp
+)
+
+add_executable(FlashnotesGUI WIN32 ${SOURCES})
+
+# Include headers from parent project
+target_include_directories(FlashnotesGUI PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Link against core libraries
+target_link_libraries(FlashnotesGUI PRIVATE controllers services domain utils)
+
+# Enable C++/CLI
+set_target_properties(FlashnotesGUI PROPERTIES
+    COMMON_LANGUAGE_RUNTIME ""
+)
+set_target_properties(FlashnotesGUI PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
+
+# Explicitly add /clr and enable asynchronous exceptions with /EHa
+target_compile_options(FlashnotesGUI PRIVATE "/clr" "/EHa")

--- a/Flashnotes/src/gui/FileManagerForm.cpp
+++ b/Flashnotes/src/gui/FileManagerForm.cpp
@@ -1,0 +1,38 @@
+#include "FileManagerForm.h"
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+#include <msclr/marshal_cppstd.h>
+
+namespace FlashnotesGUI {
+
+FileManagerForm::FileManagerForm(flashnotes::FileController* ctrl)
+{
+    controller = ctrl;
+    Dock = DockStyle::Fill;
+
+    fileList = gcnew ListView();
+    fileList->Dock = DockStyle::Fill;
+
+    btnAdd = gcnew Button();
+    btnAdd->Text = "Add";
+    btnAdd->Dock = DockStyle::Bottom;
+    btnAdd->Click += gcnew EventHandler(this, &FileManagerForm::onAdd);
+
+    Controls->Add(fileList);
+    Controls->Add(btnAdd);
+}
+
+void FileManagerForm::onAdd(Object^ sender, EventArgs^ e)
+{
+    OpenFileDialog^ dlg = gcnew OpenFileDialog();
+    if (dlg->ShowDialog() == DialogResult::OK) {
+        auto res = controller->createFile(); // placeholder
+        if (!res)
+            MessageBox::Show(gcnew String(res.error().c_str()));
+        else
+            fileList->Items->Add(gcnew ListViewItem(gcnew String(std::to_string(res.value().id).c_str())));
+    }
+}
+
+} // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/FileManagerForm.h
+++ b/Flashnotes/src/gui/FileManagerForm.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+
+#include <controllers/FileController.hpp>
+
+using namespace System;
+using namespace System::Windows::Forms;
+
+namespace FlashnotesGUI {
+
+public ref class FileManagerForm : public UserControl
+{
+public:
+    FileManagerForm(flashnotes::FileController* ctrl);
+
+private:
+    flashnotes::FileController* controller;
+    ListView^ fileList;
+    Button^ btnAdd;
+
+    void onAdd(Object^ sender, EventArgs^ e);
+};
+
+} // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/FlashcardPracticeForm.cpp
+++ b/Flashnotes/src/gui/FlashcardPracticeForm.cpp
@@ -1,0 +1,73 @@
+#include "FlashcardPracticeForm.h"
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+#include <msclr/marshal_cppstd.h>
+
+using namespace System::Drawing; // for ContentAlignment
+
+namespace FlashnotesGUI {
+
+FlashcardPracticeForm::FlashcardPracticeForm(flashnotes::FlashcardController* ctrl)
+    : showingBack(false)
+{
+    controller = ctrl;
+    Dock = DockStyle::Fill;
+
+    lblFront = gcnew Label();
+    lblFront->Dock = DockStyle::Top;
+    lblFront->Height = 40;
+    lblFront->TextAlign = ContentAlignment::MiddleCenter;
+
+    lblBack = gcnew Label();
+    lblBack->Dock = DockStyle::Top;
+    lblBack->Height = 40;
+    lblBack->Visible = false;
+    lblBack->TextAlign = ContentAlignment::MiddleCenter;
+
+    btnFlip = gcnew Button();
+    btnFlip->Text = "Flip";
+    btnFlip->Dock = DockStyle::Top;
+    btnFlip->Click += gcnew EventHandler(this, &FlashcardPracticeForm::onFlip);
+
+    btnNext = gcnew Button();
+    btnNext->Text = "Next";
+    btnNext->Dock = DockStyle::Top;
+    btnNext->Click += gcnew EventHandler(this, &FlashcardPracticeForm::onNext);
+
+    Controls->Add(btnNext);
+    Controls->Add(btnFlip);
+    Controls->Add(lblBack);
+    Controls->Add(lblFront);
+
+    loadNext();
+}
+
+void FlashcardPracticeForm::loadNext()
+{
+    auto res = controller->getNextCards(1);
+    if (!res || res.value().empty()) {
+        lblFront->Text = "No cards";
+        lblBack->Text = "";
+        lblBack->Visible = false;
+    } else {
+        auto& c = res.value().front();
+        lblFront->Text = gcnew String(c.front.c_str());
+        lblBack->Text = gcnew String(c.back.c_str());
+        lblBack->Visible = false;
+        showingBack = false;
+    }
+}
+
+void FlashcardPracticeForm::onFlip(Object^ sender, EventArgs^ e)
+{
+    showingBack = !showingBack;
+    lblBack->Visible = showingBack;
+}
+
+void FlashcardPracticeForm::onNext(Object^ sender, EventArgs^ e)
+{
+    loadNext();
+}
+
+} // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/FlashcardPracticeForm.h
+++ b/Flashnotes/src/gui/FlashcardPracticeForm.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+
+#include <controllers/FlashcardController.hpp>
+
+using namespace System;
+using namespace System::Windows::Forms;
+
+namespace FlashnotesGUI {
+
+public ref class FlashcardPracticeForm : public UserControl
+{
+public:
+    FlashcardPracticeForm(flashnotes::FlashcardController* ctrl);
+
+private:
+    flashnotes::FlashcardController* controller;
+    Label^ lblFront;
+    Label^ lblBack;
+    Button^ btnFlip;
+    Button^ btnNext;
+    bool showingBack;
+
+    void loadNext();
+    void onFlip(Object^ sender, EventArgs^ e);
+    void onNext(Object^ sender, EventArgs^ e);
+};
+
+} // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/MainWindow.cpp
+++ b/Flashnotes/src/gui/MainWindow.cpp
@@ -1,0 +1,65 @@
+#include "MainWindow.h"
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+
+namespace FlashnotesGUI {
+
+MainWindow::MainWindow(flashnotes::AppController* ctrl)
+{
+    controller = ctrl;
+    Text = "Flashnotes \xE2\x80\x93 alpha"; // note: UTF-8 dash
+    Width = 600;
+    Height = 400;
+
+    menu = gcnew MenuStrip();
+    mainPanel = gcnew Panel();
+    mainPanel->Dock = DockStyle::Fill;
+
+    initMenu();
+    Controls->Add(mainPanel);
+    Controls->Add(menu);
+}
+
+MainWindow::~MainWindow() {}
+
+void MainWindow::initMenu()
+{
+    auto notesItem = gcnew ToolStripMenuItem("Edit Notes");
+    auto filesItem = gcnew ToolStripMenuItem("Organise Files");
+    auto flashItem = gcnew ToolStripMenuItem("Flashcards");
+    notesItem->Click += gcnew EventHandler(this, &MainWindow::onEditNotes);
+    filesItem->Click += gcnew EventHandler(this, &MainWindow::onOrganiseFiles);
+    flashItem->Click += gcnew EventHandler(this, &MainWindow::onFlashcards);
+    menu->Items->AddRange(gcnew cli::array<ToolStripItem^>{notesItem, filesItem, flashItem});
+}
+
+void MainWindow::loadControl(UserControl^ c)
+{
+    mainPanel->Controls->Clear();
+    c->Dock = DockStyle::Fill;
+    mainPanel->Controls->Add(c);
+}
+
+void MainWindow::onEditNotes(Object^ sender, EventArgs^ e)
+{
+    if (!noteEditor)
+        noteEditor = gcnew NoteEditorForm(&(controller->notes()));
+    loadControl(noteEditor);
+}
+
+void MainWindow::onOrganiseFiles(Object^ sender, EventArgs^ e)
+{
+    if (!fileManager)
+        fileManager = gcnew FileManagerForm(&(controller->files()));
+    loadControl(fileManager);
+}
+
+void MainWindow::onFlashcards(Object^ sender, EventArgs^ e)
+{
+    if (!flashcardForm)
+        flashcardForm = gcnew FlashcardPracticeForm(&(controller->flashcards()));
+    loadControl(flashcardForm);
+}
+
+} // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/MainWindow.h
+++ b/Flashnotes/src/gui/MainWindow.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+
+#include "NoteEditorForm.h"
+#include "FileManagerForm.h"
+#include "FlashcardPracticeForm.h"
+#include <controllers/AppController.hpp>
+
+using namespace System;
+using namespace System::Windows::Forms;
+
+namespace FlashnotesGUI {
+
+public ref class MainWindow : public Form
+{
+public:
+    MainWindow(flashnotes::AppController* ctrl);
+
+protected:
+    ~MainWindow();
+
+private:
+    flashnotes::AppController* controller;
+    MenuStrip^ menu;
+    Panel^ mainPanel;
+    NoteEditorForm^ noteEditor;
+    FileManagerForm^ fileManager;
+    FlashcardPracticeForm^ flashcardForm;
+
+    void initMenu();
+    void loadControl(UserControl^ c);
+    void onEditNotes(Object^ sender, EventArgs^ e);
+    void onOrganiseFiles(Object^ sender, EventArgs^ e);
+    void onFlashcards(Object^ sender, EventArgs^ e);
+};
+
+} // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/NoteEditorForm.cpp
+++ b/Flashnotes/src/gui/NoteEditorForm.cpp
@@ -1,0 +1,42 @@
+#include "NoteEditorForm.h"
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+#include <msclr/marshal_cppstd.h>
+
+namespace FlashnotesGUI {
+
+NoteEditorForm::NoteEditorForm(flashnotes::NotesController* ctrl)
+{
+    controller = ctrl;
+    Dock = DockStyle::Fill;
+
+    noteTitle = gcnew TextBox();
+    noteTitle->Dock = DockStyle::Top;
+
+    noteBody = gcnew TextBox();
+    noteBody->Multiline = true;
+    noteBody->Dock = DockStyle::Fill;
+
+    btnSave = gcnew Button();
+    btnSave->Text = "Save";
+    btnSave->Dock = DockStyle::Bottom;
+    btnSave->Click += gcnew EventHandler(this, &NoteEditorForm::onSave);
+
+    Controls->Add(noteBody);
+    Controls->Add(btnSave);
+    Controls->Add(noteTitle);
+}
+
+void NoteEditorForm::onSave(Object^ sender, EventArgs^ e)
+{
+    std::string title = msclr::interop::marshal_as<std::string>(noteTitle->Text);
+    std::string body = msclr::interop::marshal_as<std::string>(noteBody->Text);
+    auto res = controller->createNote(title, body, ".");
+    if (!res)
+        MessageBox::Show(gcnew String(res.error().c_str()));
+    else
+        MessageBox::Show("Saved!");
+}
+
+} // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/NoteEditorForm.h
+++ b/Flashnotes/src/gui/NoteEditorForm.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+
+#include <controllers/NotesController.hpp>
+
+using namespace System;
+using namespace System::Windows::Forms;
+
+namespace FlashnotesGUI {
+
+public ref class NoteEditorForm : public UserControl
+{
+public:
+    NoteEditorForm(flashnotes::NotesController* ctrl);
+
+private:
+    flashnotes::NotesController* controller;
+    TextBox^ noteTitle;
+    TextBox^ noteBody;
+    Button^ btnSave;
+
+    void onSave(Object^ sender, EventArgs^ e);
+};
+
+} // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/Program.cpp
+++ b/Flashnotes/src/gui/Program.cpp
@@ -1,0 +1,17 @@
+#include "MainWindow.h"
+#using <System.dll>
+#using <System.Windows.Forms.dll>
+#using <System.Drawing.dll>
+#include <controllers/AppController.hpp>
+
+using namespace System;
+using namespace System::Windows::Forms;
+
+int main(array<String^>^ args)
+{
+    flashnotes::AppController app;
+    Application::EnableVisualStyles();
+    Application::SetCompatibleTextRenderingDefault(false);
+    Application::Run(gcnew FlashnotesGUI::MainWindow(&app));
+    return 0;
+}

--- a/Flashnotes/tests/file_service.cpp
+++ b/Flashnotes/tests/file_service.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define UNIT_TEST
 #include "services/FileService.hpp"
 #include "services/JsonPersistenceService.hpp"
 #include <filesystem>

--- a/Flashnotes/tests/flashcard_service.cpp
+++ b/Flashnotes/tests/flashcard_service.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define UNIT_TEST
 #include "services/FlashcardService.hpp"
 #include "services/JsonPersistenceService.hpp"
 #include <filesystem>

--- a/Flashnotes/tests/notes_controller.cpp
+++ b/Flashnotes/tests/notes_controller.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define UNIT_TEST
 #include "controllers/NotesController.hpp"
 #include "services/JsonPersistenceService.hpp"
 #include <filesystem>

--- a/Flashnotes/tests/notes_service.cpp
+++ b/Flashnotes/tests/notes_service.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define UNIT_TEST
 #include "services/NotesService.hpp"
 #include "services/JsonPersistenceService.hpp"
 #include <filesystem>

--- a/Flashnotes/tests/persistence_folder.cpp
+++ b/Flashnotes/tests/persistence_folder.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define UNIT_TEST
 #include "services/JsonPersistenceService.hpp"
 #include <filesystem>
 

--- a/Flashnotes/tests/persistence_note.cpp
+++ b/Flashnotes/tests/persistence_note.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define UNIT_TEST
 #include "services/JsonPersistenceService.hpp"
 #include <filesystem>
 


### PR DESCRIPTION
## Summary
- add optional WinForms GUI project using C++/CLI
- show simple forms wired to controllers
- compile GUI only when building with MSVC
- refine build flags so UNIT_TEST definition doesn't leak to GUI

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6841a8105f24832c8ed873a9430c24d6