### PR TITLE
Fix Windows Forms header collisions

### DIFF
--- a/Flashnotes/src/gui/FileManagerForm.h
+++ b/Flashnotes/src/gui/FileManagerForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/FileController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class FileManagerForm : public UserControl
 {

--- a/Flashnotes/src/gui/FlashcardPracticeForm.h
+++ b/Flashnotes/src/gui/FlashcardPracticeForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/FlashcardController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class FlashcardPracticeForm : public UserControl
 {

--- a/Flashnotes/src/gui/MainWindow.h
+++ b/Flashnotes/src/gui/MainWindow.h
@@ -9,10 +9,9 @@
 #include "FlashcardPracticeForm.h"
 #include <controllers/AppController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class MainWindow : public Form
 {

--- a/Flashnotes/src/gui/NoteEditorForm.h
+++ b/Flashnotes/src/gui/NoteEditorForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/NotesController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class NoteEditorForm : public UserControl
 {


### PR DESCRIPTION
## Summary
- scope `System` and `System::Windows::Forms` using directives inside FlashnotesGUI headers

These changes avoid polluting the global namespace with managed `IDataObject` and other interface types so that native Windows headers can coexist without redefinition errors.

## Testing
- `cmake -B build -S Flashnotes`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6842a4b328b0832c846a1e5e0fe91bfb