### PR TITLE
Fix Windows entry point for GUI

### DIFF
--- a/Flashnotes/src/gui/FileManagerForm.h
+++ b/Flashnotes/src/gui/FileManagerForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/FileController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class FileManagerForm : public UserControl
 {

--- a/Flashnotes/src/gui/FlashcardPracticeForm.h
+++ b/Flashnotes/src/gui/FlashcardPracticeForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/FlashcardController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class FlashcardPracticeForm : public UserControl
 {

--- a/Flashnotes/src/gui/MainWindow.h
+++ b/Flashnotes/src/gui/MainWindow.h
@@ -9,10 +9,9 @@
 #include "FlashcardPracticeForm.h"
 #include <controllers/AppController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class MainWindow : public Form
 {

--- a/Flashnotes/src/gui/NoteEditorForm.h
+++ b/Flashnotes/src/gui/NoteEditorForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/NotesController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class NoteEditorForm : public UserControl
 {

--- a/Flashnotes/src/gui/Program.cpp
+++ b/Flashnotes/src/gui/Program.cpp
@@ -3,6 +3,7 @@
 #using <System.Windows.Forms.dll>
 #using <System.Drawing.dll>
 #include <controllers/AppController.hpp>
+#include <Windows.h>
 
 using namespace System;
 using namespace System::Windows::Forms;
@@ -14,4 +15,13 @@ int main(array<String^>^ args)
     Application::SetCompatibleTextRenderingDefault(false);
     Application::Run(gcnew FlashnotesGUI::MainWindow(&app));
     return 0;
+}
+
+// MSVC expects a WinMain entry point when building a WIN32
+// subsystem executable. Provide a thin wrapper that forwards
+// to the CLI main function so linking succeeds.
+[STAThreadAttribute]
+int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
+{
+    return main(Environment::GetCommandLineArgs());
 }


### PR DESCRIPTION
## Summary
- add Windows `WinMain` wrapper in Program.cpp

## Testing
- `cmake -B build -S Flashnotes`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6842a4b328b0832c846a1e5e0fe91bfb