### PR TITLE
Add note browsing to GUI

### DIFF
--- a/Flashnotes/src/gui/FileManagerForm.h
+++ b/Flashnotes/src/gui/FileManagerForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/FileController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class FileManagerForm : public UserControl
 {

--- a/Flashnotes/src/gui/FlashcardPracticeForm.h
+++ b/Flashnotes/src/gui/FlashcardPracticeForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/FlashcardController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class FlashcardPracticeForm : public UserControl
 {

--- a/Flashnotes/src/gui/MainWindow.h
+++ b/Flashnotes/src/gui/MainWindow.h
@@ -9,10 +9,9 @@
 #include "FlashcardPracticeForm.h"
 #include <controllers/AppController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class MainWindow : public Form
 {

--- a/Flashnotes/src/gui/NoteEditorForm.cpp
+++ b/Flashnotes/src/gui/NoteEditorForm.cpp
@@ -11,12 +11,22 @@ NoteEditorForm::NoteEditorForm(flashnotes::NotesController* ctrl)
     controller = ctrl;
     Dock = DockStyle::Fill;
 
+    noteList = gcnew ListBox();
+    noteList->Dock = DockStyle::Left;
+    noteList->Width = 150;
+    noteList->SelectedIndexChanged += gcnew EventHandler(this, &NoteEditorForm::onSelect);
+
     noteTitle = gcnew TextBox();
     noteTitle->Dock = DockStyle::Top;
 
     noteBody = gcnew TextBox();
     noteBody->Multiline = true;
     noteBody->Dock = DockStyle::Fill;
+
+    btnOpen = gcnew Button();
+    btnOpen->Text = "Open";
+    btnOpen->Dock = DockStyle::Bottom;
+    btnOpen->Click += gcnew EventHandler(this, &NoteEditorForm::onOpen);
 
     btnSave = gcnew Button();
     btnSave->Text = "Save";
@@ -25,18 +35,73 @@ NoteEditorForm::NoteEditorForm(flashnotes::NotesController* ctrl)
 
     Controls->Add(noteBody);
     Controls->Add(btnSave);
+    Controls->Add(btnOpen);
     Controls->Add(noteTitle);
+    Controls->Add(noteList);
+
+    loadNotes();
 }
 
 void NoteEditorForm::onSave(Object^ sender, EventArgs^ e)
 {
     std::string title = msclr::interop::marshal_as<std::string>(noteTitle->Text);
     std::string body = msclr::interop::marshal_as<std::string>(noteBody->Text);
-    auto res = controller->createNote(title, body, ".");
+
+    SaveFileDialog^ dlg = gcnew SaveFileDialog();
+    dlg->FileName = gcnew String(title.c_str());
+    if (dlg->ShowDialog() != DialogResult::OK)
+        return;
+    std::string path = msclr::interop::marshal_as<std::string>(dlg->FileName);
+
+    auto res = controller->createNote(title, body, path);
     if (!res)
         MessageBox::Show(gcnew String(res.error().c_str()));
     else
+    {
+        System::IO::File::WriteAllText(dlg->FileName, gcnew String(body.c_str()));
         MessageBox::Show("Saved!");
+    }
+
+    loadNotes();
+}
+
+void NoteEditorForm::loadNotes()
+{
+    noteList->Items->Clear();
+    auto res = controller->listNotes();
+    if (!res) {
+        MessageBox::Show(gcnew String(res.error().c_str()));
+        return;
+    }
+    for (const auto& n : res.value()) {
+        noteList->Items->Add(gcnew String(n.title.c_str()));
+    }
+}
+
+void NoteEditorForm::onSelect(Object^ sender, EventArgs^ e)
+{
+    int idx = noteList->SelectedIndex;
+    if (idx < 0) return;
+    auto res = controller->listNotes();
+    if (!res || idx >= static_cast<int>(res.value().size())) return;
+    auto& n = res.value()[idx];
+    noteTitle->Text = gcnew String(n.title.c_str());
+    noteBody->Text = gcnew String(n.body.c_str());
+}
+
+void NoteEditorForm::onOpen(Object^ sender, EventArgs^ e)
+{
+    int idx = noteList->SelectedIndex;
+    if (idx < 0) return;
+    auto res = controller->listNotes();
+    if (!res || idx >= static_cast<int>(res.value().size())) return;
+    auto& n = res.value()[idx];
+    if (!n.savedPath.empty()) {
+        System::String^ path = gcnew System::String(n.savedPath.c_str());
+        if (System::IO::File::Exists(path)) {
+            System::Diagnostics::Process::Start(path);
+        }
+    }
 }
 
 } // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/NoteEditorForm.h
+++ b/Flashnotes/src/gui/NoteEditorForm.h
@@ -6,10 +6,9 @@
 
 #include <controllers/NotesController.hpp>
 
+namespace FlashnotesGUI {
 using namespace System;
 using namespace System::Windows::Forms;
-
-namespace FlashnotesGUI {
 
 public ref class NoteEditorForm : public UserControl
 {
@@ -18,10 +17,15 @@ public:
 
 private:
     flashnotes::NotesController* controller;
+    ListBox^ noteList;
     TextBox^ noteTitle;
     TextBox^ noteBody;
     Button^ btnSave;
+    Button^ btnOpen;
 
+    void loadNotes();
+    void onSelect(Object^ sender, EventArgs^ e);
+    void onOpen(Object^ sender, EventArgs^ e);
     void onSave(Object^ sender, EventArgs^ e);
 };
 

--- a/Flashnotes/src/gui/Program.cpp
+++ b/Flashnotes/src/gui/Program.cpp
@@ -3,6 +3,7 @@
 #using <System.Windows.Forms.dll>
 #using <System.Drawing.dll>
 #include <controllers/AppController.hpp>
+#include <Windows.h>
 
 using namespace System;
 using namespace System::Windows::Forms;
@@ -14,4 +15,13 @@ int main(array<String^>^ args)
     Application::SetCompatibleTextRenderingDefault(false);
     Application::Run(gcnew FlashnotesGUI::MainWindow(&app));
     return 0;
+}
+
+// MSVC expects a WinMain entry point when building a WIN32
+// subsystem executable. Provide a thin wrapper that forwards
+// to the CLI main function so linking succeeds.
+[STAThreadAttribute]
+int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
+{
+    return main(Environment::GetCommandLineArgs());
 }


### PR DESCRIPTION
## Summary
- list stored notes on the WinForms notes screen
- allow selecting a note title and loading its contents
- provide an Open button that launches the saved file if it exists

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6842a4b328b0832c846a1e5e0fe91bfb