### PR TITLE
Adjust layout of editor forms

### DIFF
--- a/Flashnotes/src/gui/FlashcardSetEditorForm.cpp
+++ b/Flashnotes/src/gui/FlashcardSetEditorForm.cpp
@@ -41,8 +41,8 @@ FlashcardSetEditorForm::FlashcardSetEditorForm(flashnotes::FlashcardSetControlle
     bar->Controls->AddRange(gcnew cli::array<Control^>{btnNew, btnOpen, btnSave, btnUpdate, btnDelete, btnAddCard, btnRemoveCard});
 
     Controls->Add(grid);
-    Controls->Add(bar);
     Controls->Add(titleBox);
+    Controls->Add(bar);
     Controls->Add(setList);
 
     loadSets();

--- a/Flashnotes/src/gui/NoteEditorForm.cpp
+++ b/Flashnotes/src/gui/NoteEditorForm.cpp
@@ -59,8 +59,8 @@ NoteEditorForm::NoteEditorForm(flashnotes::NotesController* ctrl)
     bar->Controls->AddRange(gcnew cli::array<Control^>{btnNew, btnOpen, btnSave, btnUpdate, btnDelete});
 
     Controls->Add(noteBody);
-    Controls->Add(bar);
     Controls->Add(noteTitle);
+    Controls->Add(bar);
     Controls->Add(noteList);
 
     loadNotes();


### PR DESCRIPTION
## Summary
- reorder controls in NoteEditorForm so title sits below the action bar
- reorder controls in FlashcardSetEditorForm so title box appears below the buttons

## Testing
- `cmake -B build -S Flashnotes`
- `cmake --build build -- -j4`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68468dad1d20832cb0d9a1b4a919a4a0