### PR TITLE
Add folder management to file system

### DIFF
--- a/Flashnotes/include/controllers/FileController.hpp
+++ b/Flashnotes/include/controllers/FileController.hpp
@@ -2,7 +2,10 @@
 #include <memory>
 #include <vector>
 #include "domain/material.hpp"
+#include "domain/folder.hpp"
 #include "services/FileService.hpp"
+#include <filesystem>
+#include <string>
 #include "utils/Expected.hpp"
 
 namespace flashnotes {
@@ -12,9 +15,14 @@ public:
     FileController();
     explicit FileController(std::shared_ptr<FileService> svc);
 
-    Expected<Material> createFile();
+    Expected<Material> createFile(const std::filesystem::path& path, int folderId = -1);
     Expected<std::vector<Material>> listFiles() const;
     Expected<void> removeFile(std::uint64_t id);
+
+    Expected<Folder> createFolder(const std::string& name, int parentId = -1);
+    Expected<Folder> updateFolder(std::uint64_t id, const std::string& name);
+    Expected<std::vector<Folder>> listFolders() const;
+    Expected<void> removeFolder(std::uint64_t id);
 
 private:
     std::shared_ptr<FileService> service_;

--- a/Flashnotes/include/domain/folder.hpp
+++ b/Flashnotes/include/domain/folder.hpp
@@ -9,8 +9,8 @@ namespace flashnotes {
 
 struct Folder {
     int id{};
+    int parentId{-1};
     std::string name;
-    std::vector<int> childrenIds;
 };
 
 void to_json(nlohmann::json& j, const Folder& f);

--- a/Flashnotes/include/domain/material.hpp
+++ b/Flashnotes/include/domain/material.hpp
@@ -7,10 +7,21 @@ namespace flashnotes {
 
 struct Material {
     int id{};
+    std::string title;
+    std::string path;
+    int folderId{-1};
 };
 
-inline void to_json(nlohmann::json& j, const Material& m) { j = nlohmann::json{{"id", m.id}}; }
-inline void from_json(const nlohmann::json& j, Material& m) { j.at("id").get_to(m.id); }
+inline void to_json(nlohmann::json& j, const Material& m) {
+    j = nlohmann::json{{"id", m.id}, {"title", m.title}, {"path", m.path}, {"folderId", m.folderId}};
+}
+
+inline void from_json(const nlohmann::json& j, Material& m) {
+    j.at("id").get_to(m.id);
+    j.at("title").get_to(m.title);
+    j.at("path").get_to(m.path);
+    j.at("folderId").get_to(m.folderId);
+}
 
 } // namespace flashnotes
 

--- a/Flashnotes/include/services/FileService.hpp
+++ b/Flashnotes/include/services/FileService.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <vector>
+#include <string>
 #include <filesystem>
 #include "domain/material.hpp"
+#include "domain/folder.hpp"
 #include "services/JsonPersistenceService.hpp"
 
 namespace flashnotes {
@@ -9,13 +11,20 @@ namespace flashnotes {
 class FileService {
 public:
     FileService();
-    Material create();
+    Material create(const std::filesystem::path& path, int folderId = -1);
     std::vector<Material> list() const;
     void remove(std::uint64_t id);
 
+    Folder createFolder(const std::string& name, int parentId = -1);
+    Folder updateFolder(std::uint64_t id, const std::string& name);
+    std::vector<Folder> listFolders() const;
+    void removeFolder(std::uint64_t id);
+
 private:
     std::vector<Material> cache_;
+    std::vector<Folder> folders_;
     int nextId() const;
+    int nextFolderId() const;
     void syncFromDisk();
     void syncToDisk() const;
 };

--- a/Flashnotes/src/controllers/FileController.cpp
+++ b/Flashnotes/src/controllers/FileController.cpp
@@ -8,9 +8,9 @@ FileController::FileController()
 FileController::FileController(std::shared_ptr<FileService> svc)
     : service_(std::move(svc)) {}
 
-Expected<Material> FileController::createFile() {
+Expected<Material> FileController::createFile(const std::filesystem::path& path, int folderId) {
     try {
-        return service_->create();
+        return service_->create(path, folderId);
     } catch (const std::exception& e) {
         return Expected<Material>(e.what());
     }
@@ -27,6 +27,39 @@ Expected<std::vector<Material>> FileController::listFiles() const {
 Expected<void> FileController::removeFile(std::uint64_t id) {
     try {
         service_->remove(id);
+        return Expected<void>();
+    } catch (const std::exception& e) {
+        return Expected<void>(e.what());
+    }
+}
+
+Expected<Folder> FileController::createFolder(const std::string& name, int parentId) {
+    try {
+        return service_->createFolder(name, parentId);
+    } catch (const std::exception& e) {
+        return Expected<Folder>(e.what());
+    }
+}
+
+Expected<Folder> FileController::updateFolder(std::uint64_t id, const std::string& name) {
+    try {
+        return service_->updateFolder(id, name);
+    } catch (const std::exception& e) {
+        return Expected<Folder>(e.what());
+    }
+}
+
+Expected<std::vector<Folder>> FileController::listFolders() const {
+    try {
+        return service_->listFolders();
+    } catch (const std::exception& e) {
+        return Expected<std::vector<Folder>>(e.what());
+    }
+}
+
+Expected<void> FileController::removeFolder(std::uint64_t id) {
+    try {
+        service_->removeFolder(id);
         return Expected<void>();
     } catch (const std::exception& e) {
         return Expected<void>(e.what());

--- a/Flashnotes/src/domain/folder.cpp
+++ b/Flashnotes/src/domain/folder.cpp
@@ -3,13 +3,13 @@
 namespace flashnotes {
 
 void to_json(nlohmann::json& j, const Folder& f) {
-    j = nlohmann::json{{"id", f.id}, {"name", f.name}, {"childrenIds", f.childrenIds}};
+    j = nlohmann::json{{"id", f.id}, {"parentId", f.parentId}, {"name", f.name}};
 }
 
 void from_json(const nlohmann::json& j, Folder& f) {
     j.at("id").get_to(f.id);
+    j.at("parentId").get_to(f.parentId);
     j.at("name").get_to(f.name);
-    j.at("childrenIds").get_to(f.childrenIds);
 }
 
 } // namespace flashnotes

--- a/Flashnotes/src/gui/FileManagerForm.cpp
+++ b/Flashnotes/src/gui/FileManagerForm.cpp
@@ -2,6 +2,7 @@
 #using <System.dll>
 #using <System.Windows.Forms.dll>
 #using <System.Drawing.dll>
+#using <Microsoft.VisualBasic.dll>
 #include <msclr/marshal_cppstd.h>
 
 namespace FlashnotesGUI {
@@ -11,28 +12,122 @@ FileManagerForm::FileManagerForm(flashnotes::FileController* ctrl)
     controller = ctrl;
     Dock = DockStyle::Fill;
 
-    fileList = gcnew ListView();
-    fileList->Dock = DockStyle::Fill;
+    tree = gcnew TreeView();
+    tree->Dock = DockStyle::Fill;
 
-    btnAdd = gcnew Button();
-    btnAdd->Text = "Add";
-    btnAdd->Dock = DockStyle::Bottom;
-    btnAdd->Click += gcnew EventHandler(this, &FileManagerForm::onAdd);
+    FlowLayoutPanel^ bar = gcnew FlowLayoutPanel();
+    bar->Dock = DockStyle::Bottom;
 
-    Controls->Add(fileList);
-    Controls->Add(btnAdd);
+    btnAddFile = gcnew Button();
+    btnAddFile->Text = "Add File";
+    btnAddFile->Click += gcnew EventHandler(this, &FileManagerForm::onAddFile);
+
+    btnAddFolder = gcnew Button();
+    btnAddFolder->Text = "Add Folder";
+    btnAddFolder->Click += gcnew EventHandler(this, &FileManagerForm::onAddFolder);
+
+    btnOpen = gcnew Button();
+    btnOpen->Text = "Open";
+    btnOpen->Click += gcnew EventHandler(this, &FileManagerForm::onOpen);
+
+    btnDelete = gcnew Button();
+    btnDelete->Text = "Delete";
+    btnDelete->Click += gcnew EventHandler(this, &FileManagerForm::onDelete);
+
+    bar->Controls->AddRange(gcnew cli::array<Control^>{btnAddFile, btnAddFolder, btnOpen, btnDelete});
+
+    Controls->Add(tree);
+    Controls->Add(bar);
+
+    loadData();
 }
 
-void FileManagerForm::onAdd(Object^ sender, EventArgs^ e)
+void FileManagerForm::loadData()
+{
+    tree->Nodes->Clear();
+    auto foldersRes = controller->listFolders();
+    auto filesRes = controller->listFiles();
+    if (!foldersRes || !filesRes) return;
+    auto folders = foldersRes.value();
+    auto files = filesRes.value();
+
+    System::Collections::Generic::Dictionary<int, TreeNode^>^ nodes = gcnew System::Collections::Generic::Dictionary<int, TreeNode^>();
+    for (const auto& f : folders) {
+        TreeNode^ n = gcnew TreeNode(gcnew String(f.name.c_str()));
+        n->Tag = System::Tuple::Create(true, f.id);
+        nodes[f.id] = n;
+        if (f.parentId == -1) tree->Nodes->Add(n);
+    }
+    for (const auto& f : folders) {
+        if (f.parentId != -1 && nodes->ContainsKey(f.parentId))
+            nodes[f.parentId]->Nodes->Add(nodes[f.id]);
+    }
+
+    for (const auto& m : files) {
+        TreeNode^ node = gcnew TreeNode(gcnew String(m.title.c_str()));
+        node->Tag = System::Tuple::Create(false, m.id);
+        if (m.folderId != -1 && nodes->ContainsKey(m.folderId))
+            nodes[m.folderId]->Nodes->Add(node);
+        else
+            tree->Nodes->Add(node);
+    }
+    tree->ExpandAll();
+}
+
+void FileManagerForm::onAddFile(Object^ sender, EventArgs^ e)
 {
     OpenFileDialog^ dlg = gcnew OpenFileDialog();
     if (dlg->ShowDialog() == DialogResult::OK) {
-        auto res = controller->createFile(); // placeholder
+        int folderId = -1;
+        if (tree->SelectedNode && safe_cast<System::Tuple<bool,int>^>(tree->SelectedNode->Tag)->Item1)
+            folderId = safe_cast<System::Tuple<bool,int>^>(tree->SelectedNode->Tag)->Item2;
+        auto res = controller->createFile(msclr::interop::marshal_as<std::string>(dlg->FileName), folderId);
         if (!res)
             MessageBox::Show(gcnew String(res.error().c_str()));
-        else
-            fileList->Items->Add(gcnew ListViewItem(gcnew String(std::to_string(res.value().id).c_str())));
+        loadData();
     }
+}
+
+void FileManagerForm::onAddFolder(Object^ sender, EventArgs^ e)
+{
+    String^ name = Microsoft::VisualBasic::Interaction::InputBox("Folder name", "New Folder");
+    if (!String::IsNullOrWhiteSpace(name)) {
+        int parentId = -1;
+        if (tree->SelectedNode && safe_cast<System::Tuple<bool,int>^>(tree->SelectedNode->Tag)->Item1)
+            parentId = safe_cast<System::Tuple<bool,int>^>(tree->SelectedNode->Tag)->Item2;
+        auto res = controller->createFolder(msclr::interop::marshal_as<std::string>(name), parentId);
+        if (!res)
+            MessageBox::Show(gcnew String(res.error().c_str()));
+        loadData();
+    }
+}
+
+void FileManagerForm::onOpen(Object^ sender, EventArgs^ e)
+{
+    if (!tree->SelectedNode) return;
+    auto tag = safe_cast<System::Tuple<bool,int>^>(tree->SelectedNode->Tag);
+    if (!tag->Item1) {
+        auto files = controller->listFiles();
+        if (!files) return;
+        for (const auto& m : files.value()) {
+            if (m.id == tag->Item2) {
+                System::Diagnostics::Process::Start(gcnew String(m.path.c_str()));
+                break;
+            }
+        }
+    }
+}
+
+void FileManagerForm::onDelete(Object^ sender, EventArgs^ e)
+{
+    if (!tree->SelectedNode) return;
+    auto tag = safe_cast<System::Tuple<bool,int>^>(tree->SelectedNode->Tag);
+    if (tag->Item1) {
+        controller->removeFolder(tag->Item2);
+    } else {
+        controller->removeFile(tag->Item2);
+    }
+    loadData();
 }
 
 } // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/FileManagerForm.h
+++ b/Flashnotes/src/gui/FileManagerForm.h
@@ -17,10 +17,17 @@ public:
 
 private:
     flashnotes::FileController* controller;
-    ListView^ fileList;
-    Button^ btnAdd;
+    TreeView^ tree;
+    Button^ btnAddFile;
+    Button^ btnAddFolder;
+    Button^ btnOpen;
+    Button^ btnDelete;
 
-    void onAdd(Object^ sender, EventArgs^ e);
+    void loadData();
+    void onAddFile(Object^ sender, EventArgs^ e);
+    void onAddFolder(Object^ sender, EventArgs^ e);
+    void onOpen(Object^ sender, EventArgs^ e);
+    void onDelete(Object^ sender, EventArgs^ e);
 };
 
 } // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/FlashcardSetEditorForm.cpp
+++ b/Flashnotes/src/gui/FlashcardSetEditorForm.cpp
@@ -41,8 +41,8 @@ FlashcardSetEditorForm::FlashcardSetEditorForm(flashnotes::FlashcardSetControlle
     bar->Controls->AddRange(gcnew cli::array<Control^>{btnNew, btnOpen, btnSave, btnUpdate, btnDelete, btnAddCard, btnRemoveCard});
 
     Controls->Add(grid);
-    Controls->Add(bar);
     Controls->Add(titleBox);
+    Controls->Add(bar);
     Controls->Add(setList);
 
     loadSets();

--- a/Flashnotes/src/gui/NoteEditorForm.cpp
+++ b/Flashnotes/src/gui/NoteEditorForm.cpp
@@ -59,8 +59,8 @@ NoteEditorForm::NoteEditorForm(flashnotes::NotesController* ctrl)
     bar->Controls->AddRange(gcnew cli::array<Control^>{btnNew, btnOpen, btnSave, btnUpdate, btnDelete});
 
     Controls->Add(noteBody);
-    Controls->Add(bar);
     Controls->Add(noteTitle);
+    Controls->Add(bar);
     Controls->Add(noteList);
 
     loadNotes();

--- a/Flashnotes/src/main.cpp
+++ b/Flashnotes/src/main.cpp
@@ -19,7 +19,7 @@ int main() {
         }
         std::cout << "Notes count: " << notes.value().size() << std::endl;
 
-        auto mat = app.files().createFile();
+        auto mat = app.files().createFile("/tmp/test.txt");
         if (!mat) {
             std::cerr << mat.error() << std::endl;
             return 1;

--- a/Flashnotes/src/services/FileService.cpp
+++ b/Flashnotes/src/services/FileService.cpp
@@ -1,5 +1,7 @@
 #include "services/FileService.hpp"
 #include <algorithm>
+#include <filesystem>
+#include <stdexcept>
 
 namespace flashnotes {
 
@@ -11,8 +13,14 @@ int FileService::nextId() const {
     return id + 1;
 }
 
-Material FileService::create() {
-    Material m{nextId()};
+int FileService::nextFolderId() const {
+    int id = 0;
+    for (const auto& f : folders_) if (f.id > id) id = f.id;
+    return id + 1;
+}
+
+Material FileService::create(const std::filesystem::path& path, int folderId) {
+    Material m{nextId(), path.filename().string(), path.string(), folderId};
     cache_.push_back(m);
     syncToDisk();
     return m;
@@ -29,12 +37,42 @@ void FileService::remove(std::uint64_t id) {
     syncToDisk();
 }
 
+Folder FileService::createFolder(const std::string& name, int parentId) {
+    Folder f{nextFolderId(), parentId, name};
+    folders_.push_back(f);
+    syncToDisk();
+    return f;
+}
+
+Folder FileService::updateFolder(std::uint64_t id, const std::string& name) {
+    for (auto& f : folders_) {
+        if (static_cast<std::uint64_t>(f.id) == id) {
+            f.name = name;
+            syncToDisk();
+            return f;
+        }
+    }
+    throw std::runtime_error("Folder not found");
+}
+
+std::vector<Folder> FileService::listFolders() const { return folders_; }
+
+void FileService::removeFolder(std::uint64_t id) {
+    folders_.erase(std::remove_if(folders_.begin(), folders_.end(),
+                                 [id](const Folder& f){return static_cast<std::uint64_t>(f.id)==id;}),
+                   folders_.end());
+    for (auto& m : cache_) if (m.folderId == static_cast<int>(id)) m.folderId = -1;
+    syncToDisk();
+}
+
 void FileService::syncFromDisk() {
     cache_ = JsonPersistenceService::loadMaterials();
+    folders_ = JsonPersistenceService::loadFolders();
 }
 
 void FileService::syncToDisk() const {
     JsonPersistenceService::saveMaterials(cache_);
+    JsonPersistenceService::saveFolders(folders_);
 }
 
 } // namespace flashnotes

--- a/Flashnotes/tests/domain_folder.cpp
+++ b/Flashnotes/tests/domain_folder.cpp
@@ -5,11 +5,11 @@
 using flashnotes::Folder;
 using nlohmann::json;
 
-TEST(FolderTest, VectorSerialization) {
-    Folder f{3, "root", {1,2}};
+TEST(FolderTest, BasicSerialization) {
+    Folder f{3, 0, "root"};
     json j = f;
-    ASSERT_TRUE(j["childrenIds"].is_array());
+    ASSERT_EQ(j["name"], "root");
     Folder out = j.get<Folder>();
-    EXPECT_EQ(out.childrenIds.size(), 2u);
-    EXPECT_EQ(out.childrenIds[0], 1);
+    EXPECT_EQ(out.id, 3);
+    EXPECT_EQ(out.parentId, 0);
 }

--- a/Flashnotes/tests/file_service.cpp
+++ b/Flashnotes/tests/file_service.cpp
@@ -2,6 +2,7 @@
 #include "services/FileService.hpp"
 #include "services/JsonPersistenceService.hpp"
 #include <filesystem>
+#include <fstream>
 
 using namespace flashnotes;
 namespace fs = std::filesystem;
@@ -11,7 +12,9 @@ TEST(FileService, CreateList) {
     fs::remove_all(root);
     JsonPersistenceService::setDataRoot(root);
     FileService svc;
-    auto m = svc.create();
+    fs::path fake = root / "dummy.txt";
+    std::ofstream(fake).close();
+    auto m = svc.create(fake);
     auto list = svc.list();
     ASSERT_EQ(list.size(), 1u);
     EXPECT_EQ(list[0].id, m.id);
@@ -22,7 +25,9 @@ TEST(FileService, RemovePersists) {
     fs::remove_all(root);
     JsonPersistenceService::setDataRoot(root);
     FileService svc;
-    auto m = svc.create();
+    fs::path fake = root / "dummy.txt";
+    std::ofstream(fake).close();
+    auto m = svc.create(fake);
     svc.remove(m.id);
     JsonPersistenceService::setDataRoot(root);
     FileService reload;

--- a/Flashnotes/tests/persistence_folder.cpp
+++ b/Flashnotes/tests/persistence_folder.cpp
@@ -8,10 +8,10 @@ namespace fs = std::filesystem;
 TEST(Persistence, FolderRoundTrip) {
     fs::path temp = fs::temp_directory_path() / "flashnotes_folder";
     JsonPersistenceService::setDataRoot(temp);
-    std::vector<Folder> folders{{1,"f1",{2,3}},{2,"f2",{}}};
+    std::vector<Folder> folders{{1, -1, "f1"},{2,1,"f2"}};
     JsonPersistenceService::saveFolders(folders);
     auto loaded = JsonPersistenceService::loadFolders();
     ASSERT_EQ(loaded.size(), folders.size());
-    EXPECT_EQ(loaded[0].childrenIds[0], folders[0].childrenIds[0]);
-    EXPECT_EQ(loaded[1].name, folders[1].name);
+    EXPECT_EQ(loaded[0].name, folders[0].name);
+    EXPECT_EQ(loaded[1].parentId, folders[1].parentId);
 }


### PR DESCRIPTION
## Summary
- extend Material domain with title, path and folderId
- add parentId to Folder and adjust serialization
- implement folder support in FileService and FileController
- enhance FileManagerForm with tree view, open button and folder actions
- update tests for new services

## Testing
- `cmake -B build -S Flashnotes`
- `cmake --build build -- -j4`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68468dad1d20832cb0d9a1b4a919a4a0