### PR TITLE
Add typing practice mode

### DIFF
--- a/Flashnotes/src/gui/FlashcardPracticeForm.h
+++ b/Flashnotes/src/gui/FlashcardPracticeForm.h
@@ -23,8 +23,14 @@ private:
     Label^ lblBack;
     Button^ btnFlip;
     Button^ btnNext;
+    Button^ btnCheck;
+    TextBox^ answerBox;
+    ComboBox^ modeBox;
+    Label^ lblResult;
     bool showingBack;
     int currentIndex;
+    bool hasSet;
+    flashnotes::FlashcardSet currentSet;
     std::vector<flashnotes::Flashcard>* cards;
 
     void loadSets();
@@ -32,6 +38,8 @@ private:
     void loadNext();
     void onFlip(Object^ sender, EventArgs^ e);
     void onNext(Object^ sender, EventArgs^ e);
+    void onCheck(Object^ sender, EventArgs^ e);
+    void onModeChanged(Object^ sender, EventArgs^ e);
 };
 
 } // namespace FlashnotesGUI


### PR DESCRIPTION
## Summary
- add a success-rate driven typing practice mode to FlashcardPracticeForm
- update FlashcardPracticeForm UI elements to support mode selection
- persist updated success rates via FlashcardSetController

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6846d0f916b0832c93a03d9c6e1eda48