### PR TITLE
Add typing practice mode

### DIFF
--- a/Flashnotes/src/gui/FlashcardPracticeForm.cpp
+++ b/Flashnotes/src/gui/FlashcardPracticeForm.cpp
@@ -4,13 +4,22 @@
 #using <System.Drawing.dll>
 #include <msclr/marshal_cppstd.h>
 #include <vector>
+#include <algorithm>
 
 using namespace System::Drawing; // for ContentAlignment
 
 namespace FlashnotesGUI {
 
+namespace {
+bool compareSuccess(const flashnotes::Flashcard& a, const flashnotes::Flashcard& b)
+{
+    return a.successRate < b.successRate;
+}
+} // namespace
+
+
 FlashcardPracticeForm::FlashcardPracticeForm(flashnotes::FlashcardSetController* ctrl)
-    : showingBack(false), currentIndex(0)
+    : showingBack(false), currentIndex(0), hasSet(false), currentId(-1), currentTitle(nullptr)
 {
     controller = ctrl;
     cards = new std::vector<flashnotes::Flashcard>();
@@ -32,6 +41,29 @@ FlashcardPracticeForm::FlashcardPracticeForm(flashnotes::FlashcardSetController*
     lblBack->Visible = false;
     lblBack->TextAlign = ContentAlignment::MiddleCenter;
 
+    modeBox = gcnew ComboBox();
+    modeBox->Dock = DockStyle::Top;
+    modeBox->Items->Add("Flip");
+    modeBox->Items->Add("Type");
+    modeBox->SelectedIndex = 0;
+    modeBox->SelectedIndexChanged += gcnew EventHandler(this, &FlashcardPracticeForm::onModeChanged);
+
+    answerBox = gcnew TextBox();
+    answerBox->Dock = DockStyle::Top;
+    answerBox->Visible = false;
+
+    btnCheck = gcnew Button();
+    btnCheck->Text = "Check";
+    btnCheck->Dock = DockStyle::Top;
+    btnCheck->Visible = false;
+    btnCheck->Click += gcnew EventHandler(this, &FlashcardPracticeForm::onCheck);
+
+    lblResult = gcnew Label();
+    lblResult->Dock = DockStyle::Top;
+    lblResult->Height = 30;
+    lblResult->Visible = false;
+    lblResult->TextAlign = ContentAlignment::MiddleCenter;
+
     btnFlip = gcnew Button();
     btnFlip->Text = "Flip";
     btnFlip->Dock = DockStyle::Top;
@@ -43,16 +75,36 @@ FlashcardPracticeForm::FlashcardPracticeForm(flashnotes::FlashcardSetController*
     btnNext->Click += gcnew EventHandler(this, &FlashcardPracticeForm::onNext);
 
     Controls->Add(btnNext);
+    Controls->Add(btnCheck);
     Controls->Add(btnFlip);
+    Controls->Add(lblResult);
+    Controls->Add(answerBox);
     Controls->Add(lblBack);
     Controls->Add(lblFront);
+    Controls->Add(modeBox);
     Controls->Add(setList);
 
     loadSets();
 }
 
+void FlashcardPracticeForm::refreshSets()
+{
+    loadSets();
+}
+
 FlashcardPracticeForm::~FlashcardPracticeForm() {
     delete cards;
+    if (currentTitle) {
+        delete currentTitle;
+        currentTitle = nullptr;
+    }
+}
+
+void FlashcardPracticeForm::sortCards()
+{
+    if (!cards->empty()) {
+        std::sort(cards->begin(), cards->end(), compareSuccess);
+    }
 }
 
 void FlashcardPracticeForm::loadSets()
@@ -62,6 +114,8 @@ void FlashcardPracticeForm::loadSets()
     if (!res) { lblFront->Text = "Error"; return; }
     for (auto& s : res.value()) setList->Items->Add(gcnew String(s.title.c_str()));
     cards->clear();
+    currentId = -1;
+    if (currentTitle) { delete currentTitle; currentTitle = nullptr; }
     if (setList->Items->Count > 0) setList->SelectedIndex = 0;
 }
 
@@ -69,22 +123,53 @@ void FlashcardPracticeForm::onSelect(Object^, EventArgs^)
 {
     int idx = setList->SelectedIndex;
     auto res = controller->listSets();
-    if (!res || idx < 0 || idx >= static_cast<int>(res.value().size())) { cards->clear(); return; }
+    if (!res || idx < 0 || idx >= static_cast<int>(res.value().size())) {
+        cards->clear();
+        hasSet = false;
+        currentId = -1;
+        if (currentTitle) { delete currentTitle; currentTitle = nullptr; }
+        return;
+    }
     auto s = res.value()[idx];
+    if (currentTitle) { delete currentTitle; }
+    currentTitle = new std::string(s.title);
+    currentId = s.id;
+    hasSet = true;
     *cards = s.cards;
+    if (modeBox->SelectedIndex == 1)
+        sortCards();
     currentIndex = 0;
     loadNext();
 }
 
 void FlashcardPracticeForm::loadNext()
 {
-    if (cards->empty()) { lblFront->Text = "No cards"; lblBack->Visible=false; return; }
+    if (cards->empty()) {
+        lblFront->Text = "No cards";
+        lblBack->Visible = false;
+        answerBox->Visible = false;
+        btnCheck->Visible = false;
+        lblResult->Visible = false;
+        return;
+    }
+    bool typeMode = modeBox->SelectedIndex == 1;
     if (currentIndex >= static_cast<int>(cards->size())) currentIndex = 0;
     auto& c = (*cards)[currentIndex++];
     lblFront->Text = gcnew String(c.front.c_str());
-    lblBack->Text = gcnew String(c.back.c_str());
-    lblBack->Visible = false;
-    showingBack = false;
+    if (typeMode) {
+        answerBox->Text = "";
+        answerBox->Visible = true;
+        btnCheck->Visible = true;
+        lblBack->Visible = false;
+        lblResult->Visible = false;
+    } else {
+        lblBack->Text = gcnew String(c.back.c_str());
+        lblBack->Visible = false;
+        showingBack = false;
+        answerBox->Visible = false;
+        btnCheck->Visible = false;
+        lblResult->Visible = false;
+    }
 }
 
 void FlashcardPracticeForm::onFlip(Object^ sender, EventArgs^ e)
@@ -95,6 +180,33 @@ void FlashcardPracticeForm::onFlip(Object^ sender, EventArgs^ e)
 
 void FlashcardPracticeForm::onNext(Object^ sender, EventArgs^ e)
 {
+    loadNext();
+}
+
+void FlashcardPracticeForm::onCheck(Object^ sender, EventArgs^ e)
+{
+    if (cards->empty()) return;
+    int idx = currentIndex - 1;
+    if (idx < 0 || idx >= static_cast<int>(cards->size())) return;
+    auto& c = (*cards)[idx];
+    std::string ans = msclr::interop::marshal_as<std::string>(answerBox->Text);
+    bool correct = ans == c.back;
+    lblResult->Text = correct ? "Correct" : "Oops";
+    lblResult->Visible = true;
+    c.successRate = (c.successRate + (correct ? 1.0 : 0.0)) / 2.0;
+    if (hasSet && currentTitle) {
+        controller->updateSet(currentId, *currentTitle, *cards);
+    }
+    sortCards();
+    currentIndex = 0;
+}
+
+void FlashcardPracticeForm::onModeChanged(Object^, EventArgs^)
+{
+    showingBack = false;
+    currentIndex = 0;
+    if (modeBox->SelectedIndex == 1)
+        sortCards();
     loadNext();
 }
 

--- a/Flashnotes/src/gui/FlashcardPracticeForm.h
+++ b/Flashnotes/src/gui/FlashcardPracticeForm.h
@@ -5,6 +5,7 @@
 #using <System.Drawing.dll>
 
 #include <controllers/FlashcardSetController.hpp>
+#include <string>
 
 namespace FlashnotesGUI {
 using namespace System;
@@ -15,6 +16,7 @@ public ref class FlashcardPracticeForm : public UserControl
 public:
     FlashcardPracticeForm(flashnotes::FlashcardSetController* ctrl);
     ~FlashcardPracticeForm();
+    void refreshSets();
 
 private:
     flashnotes::FlashcardSetController* controller;
@@ -23,15 +25,25 @@ private:
     Label^ lblBack;
     Button^ btnFlip;
     Button^ btnNext;
+    Button^ btnCheck;
+    TextBox^ answerBox;
+    ComboBox^ modeBox;
+    Label^ lblResult;
     bool showingBack;
     int currentIndex;
+    bool hasSet;
+    int currentId;
+    std::string* currentTitle;
     std::vector<flashnotes::Flashcard>* cards;
 
     void loadSets();
+    void sortCards();
     void onSelect(Object^ sender, EventArgs^ e);
     void loadNext();
     void onFlip(Object^ sender, EventArgs^ e);
     void onNext(Object^ sender, EventArgs^ e);
+    void onCheck(Object^ sender, EventArgs^ e);
+    void onModeChanged(Object^ sender, EventArgs^ e);
 };
 
 } // namespace FlashnotesGUI

--- a/Flashnotes/src/gui/MainWindow.cpp
+++ b/Flashnotes/src/gui/MainWindow.cpp
@@ -61,6 +61,8 @@ void MainWindow::onFlashcards(Object^ sender, EventArgs^ e)
 {
     if (!flashcardForm)
         flashcardForm = gcnew FlashcardPracticeForm(&(controller->flashcardSets()));
+    else
+        flashcardForm->refreshSets();
     loadControl(flashcardForm);
 }
 


### PR DESCRIPTION
## Summary
- fix CLI compile issues in FlashcardPracticeForm
- store selected card set metadata safely
- sort cards by success rate when typing
- persist updated success rate
- refresh set list when returning to practice
- ensure UI hides typing controls in Flip mode

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6846d0f916b0832c93a03d9c6e1eda48